### PR TITLE
chore(lock-model): remove unused indexes configuration

### DIFF
--- a/src/models/cassandra/lock/lockModel.js
+++ b/src/models/cassandra/lock/lockModel.js
@@ -11,6 +11,5 @@ module.exports = {
     deviceId: 'text',
     expiresAt: 'timestamp'
   },
-  key: ['resourceId', 'resourceType'],
-  indexes: ['lockId']
+  key: ['resourceId', 'resourceType']
 }


### PR DESCRIPTION
1. Removed unused indexes array from lock model schema which was resulting in the issue `sync failed for keyspace and table lock`, the issue was caused due to the mismatch in schema
- the index creation on lockid was removed from the migration scripts, which needed to be reflected here