### PR TITLE
fix: add ExponentialReconnectionPolicy and heartbeat to Cassandra client

### DIFF
--- a/src/utils/cassandraUtil.js
+++ b/src/utils/cassandraUtil.js
@@ -21,7 +21,14 @@ _.forEach(keyspaceConfig, config => {
     clientOptions: {
       contactPoints: contactPoints,
       keyspace: config.name,
-      queryOptions: { consistency: consistency }
+      queryOptions: { consistency: consistency },
+      policies: {
+        reconnection: new cassandraDriver.policies.reconnection.ExponentialReconnectionPolicy(1000, 30000)
+      },
+      heartbeat: {
+        interval: 30,
+        timeout: 10
+      }
     },
     ormOptions: {
       defaultReplicationStrategy: replicationStrategy,


### PR DESCRIPTION
## Problem
The Cassandra client in `cassandraUtil.js` had no reconnection policy or heartbeat.
When a YugabyteDB tserver restarts, the driver holds stale connections silently.
Next query to `lock_db` fails with `ERR_LOCK_CREATION_FAILED` — content creation
breaks until knowledge-mw is manually restarted.

## Root Cause
`express-cassandra` (DataStax driver) without explicit reconnection policy does not
auto-recover dropped connections after node restart. Without heartbeat, dead connections
are not detected until the next query fails.

## Fix
Added to `clientOptions` in `src/utils/cassandraUtil.js`:
- ExponentialReconnectionPolicy(1000ms base, 30s max) — auto-reconnects with backoff
- Heartbeat (interval: 30s, timeout: 10s) — detects dead connections proactively

## Impact
- No breaking changes
- knowledge-mw recovers automatically after YugabyteDB tserver restarts
- No more manual restarts needed for lock operations
