### PR TITLE
fix(cassandra): use express-cassandra bundled driver for reconnection…

### DIFF
--- a/src/utils/cassandraUtil.js
+++ b/src/utils/cassandraUtil.js
@@ -23,7 +23,7 @@ _.forEach(keyspaceConfig, config => {
       keyspace: config.name,
       queryOptions: { consistency: consistency },
       policies: {
-        reconnection: new cassandraDriver.policies.reconnection.ExponentialReconnectionPolicy(1000, 30000)
+        reconnection: new cassandra.driver.policies.reconnection.ExponentialReconnectionPolicy(1000, 30000)
       },
       heartbeat: {
         interval: 30,


### PR DESCRIPTION
… policy

Top-level cassandra-driver instance fails instanceof check against express-cassandra's internal bundled driver. Use cassandra.driver (express-cassandra's own driver) to create the reconnection policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Cassandra database connection reliability by correcting the reconnection policy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->